### PR TITLE
Fixed 'indexOf of undefined' error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports = module.exports = function historyApiFallback (req, res, next) {
     logger('Not rewriting %s %s because the method is not GET.',
       req.method, req.url);
     return next();
-  } else if (headers.accept.indexOf('application/json') === 0) {
+  } else if (headers && headers.accept && headers.accept.indexOf('application/json') === 0) {
     logger('Not rewriting %s %s because the client prefers JSON.',
       req.method, req.url);
     return next();


### PR DESCRIPTION
Got this error lately.
Some requests wouldn't have any headers(.accept) property, for some reason.
Tests still pass
