### PR TITLE
Fix 'index' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ var middleware = history({});
 ```
 
 ### index
-Override the index (default `index.html`)
+Override the index (default `/index.html`)
 
 ```javascript
 history({
-  index: 'default.html'
+  index: '/default.html'
 });
 ```
 


### PR DESCRIPTION
Based on https://github.com/bripkens/connect-history-api-fallback/blob/v1.1.0/lib/index.js#L69