### PR TITLE
New htmlAcceptHeaders option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.?.?
+ - New `htmlAcceptHeaders` option (see `README.md`).
+
 ## v1.1.0
  - Rewrite rules are now applied before the request URL is checked for dots.
  - Rewrite rules can be defined as functions to have greater control over the `dot rule`.

--- a/README.md
+++ b/README.md
@@ -125,3 +125,12 @@ history({
   logger: console.log.bind(console)
 });
 ```
+
+### htmlAcceptHeaders
+Override the default `Accepts:` headers that are queried when matching HTML content requests (Default: `['text/html', '*/*']`).
+
+```javascript
+history({
+  htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+})
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ exports = module.exports = function historyApiFallback(options) {
         'because the client prefers JSON.'
       );
       return next();
-    } else if (!acceptsHtml(headers.accept)) {
+    } else if (!acceptsHtml(headers.accept, options)) {
       logger(
         'Not rewriting',
         req.method,
@@ -86,8 +86,14 @@ function evaluateRewriteRule(parsedUrl, match, rule) {
   });
 }
 
-function acceptsHtml(header) {
-  return header.indexOf('text/html') !== -1 || header.indexOf('*/*') !== -1;
+function acceptsHtml(header, options) {
+  options.htmlAcceptHeaders = options.htmlAcceptHeaders || ['text/html', '*/*'];
+  for (var i = 0; i < options.htmlAcceptHeaders.length; i++) {
+    if (header.indexOf(options.htmlAcceptHeaders[i]) !== -1) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function getLogger(options) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -197,3 +197,16 @@ tests['should support custom index file'] = function(test) {
   test.ok(next.called);
   test.done();
 };
+
+tests['should accept html requests based on headers option'] = function(test) {
+  req.headers.accept = '*/*';
+  middleware = historyApiFallback({
+    htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+  });
+
+  middleware(req, null, next);
+
+  test.equal(req.url, requestedUrl);
+  test.ok(next.called);
+  test.done();
+};


### PR DESCRIPTION
This PR provides a new `htmlAcceptHeaders` option. It can be used to override the default `Accepts:` headers that are queried when matching HTML content requests (Default: `['text/html', '*/*']`).

It is meant as a backwards compatible workaround for...
> When SystemJS is misconfigured and it tries to fetch modules via URLs that don't map to js files, `connect-history-api-fallback` redirects the requests to index.html (or /) in order to support the window.history.pushState location strategy. The problem with this is that System will typically error with a weird error like Uncaught SyntaxError: Unexpected token <. This error is very difficult to understand and fix.
~ https://github.com/johnpapa/lite-server/issues/51

For this case, the middleware can be configured as follows to avoid the errors and allow the misconfigured SystemJS requests to 404 rather then fallback to index.html:
```
fallbackMiddleware({htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']})
```