### PR TITLE
Add ability to specify paths to ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Ignore a list of directories so requests for your assets don't result in a redir
 history({
   ignorePaths:['/lib/','/app/']
 });
+```
 
 ### rewrites
 Override the index when the request url matches a regex pattern. You can either rewrite to a static string or use a function to transform the incoming request.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ history({
 });
 ```
 
+### ignorePaths
+Ignore a list of directories so requests for your assets don't result in a redirect and fetch unwanted content
+
+```javascript
+history({
+  ignorePaths:['/lib/','/app/']
+});
+
 ### rewrites
 Override the index when the request url matches a regex pattern. You can either rewrite to a static string or use a function to transform the incoming request.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,12 +66,33 @@ exports = module.exports = function historyApiFallback(options) {
       return next();
     }
 
+    var ignorePaths = options.ignorePaths;
+    if (ignorePaths && pathShouldBeIgnored(parsedUrl,ignorePaths)) {
+      logger(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the path is listed as a path that should be ignored. ',
+        ignorePaths
+      );
+      return next();
+    }
+
     rewriteTarget = options.index || '/index.html';
     logger('Rewriting', req.method, req.url, 'to', rewriteTarget);
     req.url = rewriteTarget;
     next();
   };
 };
+
+function pathShouldBeIgnored(parsedUrl, ignoredPaths) {
+  for (var i = 0; i < ignoredPaths.length; i++) {
+    //a little basic because it's just checking contains but probably sufficient enough
+    if (parsedUrl.indexOf(ignoredPaths[i])>-1){
+      return true;
+    }
+  }
+}
 
 function evaluateRewriteRule(parsedUrl, match, rule) {
   if (typeof rule === 'string') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ exports = module.exports = function historyApiFallback(options) {
     }
 
     var ignorePaths = options.ignorePaths;
-    if (ignorePaths && pathShouldBeIgnored(parsedUrl,ignorePaths)) {
+    if (ignorePaths && pathShouldBeIgnored(parsedUrl, ignorePaths)) {
       logger(
         'Not rewriting',
         req.method,
@@ -87,8 +87,8 @@ exports = module.exports = function historyApiFallback(options) {
 
 function pathShouldBeIgnored(parsedUrl, ignoredPaths) {
   for (var i = 0; i < ignoredPaths.length; i++) {
-    //a little basic because it's just checking contains but probably sufficient enough
-    if (parsedUrl.path.indexOf(ignoredPaths[i])>-1){
+    //a little basic because as it's using contains, but probably sufficient.
+    if (parsedUrl.path.indexOf(ignoredPaths[i]) > -1){
       return true;
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ exports = module.exports = function historyApiFallback(options) {
 function pathShouldBeIgnored(parsedUrl, ignoredPaths) {
   for (var i = 0; i < ignoredPaths.length; i++) {
     //a little basic because it's just checking contains but probably sufficient enough
-    if (parsedUrl.indexOf(ignoredPaths[i])>-1){
+    if (parsedUrl.path.indexOf(ignoredPaths[i])>-1){
       return true;
     }
   }


### PR DESCRIPTION
Thanks for the great library!

We're using this on an angular2 project right now embedded within a gulp script for our local `serve` task and it's working great. The one downside is that any requests to local resources that fail get redirected to the index page which often times results in a strange error having something to do with an unexpected `<` character.

This pull request adds the ability to configure some url patterns that if they exist in the URL being requested, the redirect to index does not happen. 

The way it's implemented _could_ result in not redirecting to index when you really wanted to but as it's opt-in via a configuration (The readme has been updated to reflect the new configuration item) I thought leaving it as wide open and configurable by the end user as possible would be a good thing.

Thoughts?

Thanks,
Randy