### PR TITLE
Use an option to serve Url includes dot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ exports = module.exports = function historyApiFallback(options) {
       }
     }
 
-    if (parsedUrl.pathname.indexOf('.') !== -1) {
+    if (parsedUrl.pathname.indexOf('.') !== -1 && !options.ignoreDot) {
       logger(
         'Not rewriting',
         req.method,


### PR DESCRIPTION
add an option `ignoreDot` to serve some url like `/invite/hello%40gmail.com`