### PR TITLE
Include support to positional parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 
+### text editors / idea
+.idea
+
 ### Node.gitignore
 
 lib-cov
@@ -16,3 +19,4 @@ logs
 results
 
 npm-debug.log
+

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ history({
 });
 ```
 
+You can use positional parameters like $1, $2, $3.
+The following will rewrite a request that matches the `/soccer/123` pattern to `/soccer-123.html`.
+
+```javascript
+history({
+  rewrites: [
+    { from: /^\/soccer\/([^\/]+)/, to: '/soccer-$1.html'}
+  ]
+});
+```
+
 Alternatively functions can be used to have more control over the rewrite process. For instance, the following listing shows how requests to `/libs/jquery/jquery.1.12.0.min.js` and the like can be routed to `./bower_components/libs/jquery/jquery.1.12.0.min.js`. You can also make use of this if you have an API version in the URL path.
 ```javascript
 history({

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,9 @@ exports = module.exports = function historyApiFallback(options) {
 
 function evaluateRewriteRule(parsedUrl, match, rule) {
   if (typeof rule === 'string') {
-    return rule;
+    return rule.replace(/\$\d+/g, function(pos){
+      return match && match[+pos.substr(1)];
+    });
   } else if (typeof rule !== 'function') {
     throw new Error('Rewrite rule can only be of type string of function.');
   }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -156,6 +156,36 @@ tests['should rewrite requested path according to rules'] = function(test) {
   test.done();
 };
 
+tests['should rewrite using positional parameters'] = function(test) {
+    req.url = '/soccer';
+    middleware = historyApiFallback({
+        rewrites: [
+            {from: /\/(soccer)/, to: '/$1.html'}
+        ]
+    });
+
+    middleware(req, null, next);
+
+    test.equal(req.url, '/soccer.html');
+    test.ok(next.called);
+    test.done();
+};
+
+tests['should rewrite using more than one positional'] = function(test) {
+    req.url = '/soccer/play';
+    middleware = historyApiFallback({
+        rewrites: [
+            {from: /\/(soccer)\/([^\/]+)/, to: '/$2-$1.html'}
+        ]
+    });
+
+    middleware(req, null, next);
+
+    test.equal(req.url, '/play-soccer.html');
+    test.ok(next.called);
+    test.done();
+};
+
 tests['should support functions as rewrite rule'] = function(test) {
   middleware = historyApiFallback({
     rewrites: [


### PR DESCRIPTION
This PR enables support to [positional parameters](https://www.gnu.org/software/bash/manual/html_node/Positional-Parameters.html) so common in server config files.