### PR TITLE
Add whitelist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ history({
 })
 ```
 
-### Whitelist
+### whitelist
 Doesn't rewrite routes if they're in the whitelist. The following will not rewrite any request starting the with the path `/api`.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -161,3 +161,14 @@ history({
   disableDotRule: true
 })
 ```
+
+### Whitelist
+Doesn't rewrite routes if they're in the whitelist. The following will not rewrite any request starting the with the path `/api`.
+
+```javascript
+history({
+  whitelist: [
+    '/api'
+  ]
+})
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 	- [verbose](#verbose)
 	- [htmlAcceptHeaders](#htmlacceptheaders)
 	- [disableDotRule](#disabledotrule)
+    - [whitelist](#whitelist)
 
 <!-- /TOC -->
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,25 @@ exports = module.exports = function historyApiFallback(options) {
       return next();
     }
 
+
+    if (options.whitelist) {
+      for (var j = 0; j < options.whitelist.length; ++j) {
+        var whitelistElement = options.whitelist[j];
+        var isWhitelistRoute = req.url.lastIndexOf(whitelistElement, 0) === 0;
+        if (isWhitelistRoute) {
+          logger(
+              'Not rewriting',
+              req.method,
+              req.url,
+              'because the path coincides with whitelisted route',
+              whitelistElement
+          );
+          return next();
+        }
+
+      }
+    }
+
     rewriteTarget = options.index || '/index.html';
     logger('Rewriting', req.method, req.url, 'to', rewriteTarget);
     req.url = rewriteTarget;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -255,9 +255,8 @@ tests['should not rewrite routes from the whitelist'] = function(test) {
     req.url = url;
     middleware = historyApiFallback({
         whitelist: [
-            '/api',
-        ],
-        verbose: true
+            '/api'
+        ]
     });
 
     middleware(req, null, next);

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -248,3 +248,21 @@ tests['should support custom rewrite rules'] = function(test) {
   test.ok(next.called);
   test.done();
 };
+
+tests['should not rewrite routes from the whitelist'] = function(test) {
+    req.headers.accept = '*/*';
+    var url = '/api/user/32';
+    req.url = url;
+    middleware = historyApiFallback({
+        whitelist: [
+            '/api',
+        ],
+        verbose: true
+    });
+
+    middleware(req, null, next);
+
+    test.equal(req.url, url);
+    test.ok(next.called);
+    test.done();
+};


### PR DESCRIPTION
Option for when you don't want any specific routes to be rewritten. Useful when you're hosting front-end and back-end in the same server.