### PR TITLE
Only check the last pathname component for dot rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,8 @@ exports = module.exports = function historyApiFallback(options) {
       }
     }
 
-    if (parsedUrl.pathname.indexOf('.') !== -1 &&
+    var pathname = parsedUrl.pathname;
+    if (pathname.lastIndexOf('.') > pathname.lastIndexOf('/') &&
         options.disableDotRule !== true) {
       logger(
         'Not rewriting',


### PR DESCRIPTION
This PR makes the dot rule only check for a dot (`.`) after last slash (`/`) in the URL.

I have a URL that contains `.` in the middle of the pathname like `/test/a.b.c/20171012`. I cannot disable dot rule because I need it to skip rewriting static assets, and I don't want to create complex rewrite rules to overcome this issue.

I understand that ultimately when it comes to the last component of the pathname, there is no way to tell unless I explicitly set a rewrite rule. However, by checking only the last component, the default behavior is less surprising to users, at least in the case of having dots in the middle of the pathname.