### PR TITLE
Add excludes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ history({
 });
 ```
 
+### excludes
+Exclude some paths from library processing.
+
+The following will exclude all calls to api.
+```javascript
+history({
+  excludes: [
+    /^\/api\//
+  ]
+});
+```
+
 ### rewrites
 Override the index when the request url matches a regex pattern. You can either rewrite to a static string or use a function to transform the incoming request.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,14 @@ exports = module.exports = function historyApiFallback(options) {
         'because the path includes a dot (.) character.'
       );
       return next();
+    } else if (options.excludes.some(function (exclude) { return pathname.match(exclude); })) {
+      logger(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the path in excludes'
+      );
+      return next();
     }
 
     rewriteTarget = options.index || '/index.html';


### PR DESCRIPTION
I touch issue, when connect-history-api-fallback grab requests to API, and user can't open it in new tab, without special tool, like postman, that allow to create custom headers.

So I created additional option, that allow to exclude some paths from processing.