### PR TITLE
fix: remove the slash from index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As your application is a SPA, the web server will fail trying to retrieve the fi
 message to the user.
 
 This tiny middleware addresses some of the issues. Specifically, it will change
-the requested location to the index you specify (default being `/index.html`)
+the requested location to the index you specify (default being `index.html`)
 whenever there is a request which fulfills the following criteria:
 
  1. The request is a GET request
@@ -85,13 +85,13 @@ var middleware = history({});
 ```
 
 ### index
-Override the index (default `/index.html`). This is the request path that will be used when the middleware identifies that the request path needs to be rewritten.
+Override the index (default `index.html`). This is the request path that will be used when the middleware identifies that the request path needs to be rewritten.
 
 This is not the path to a file on disk. Instead it is the HTTP request path. Downstream connect/express middleware is responsible to turn this rewritten HTTP request path into actual responses, e.g. by reading a file from disk.
 
 ```javascript
 history({
-  index: '/default.html'
+  index: 'default.html'
 });
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,7 @@ exports = module.exports = function historyApiFallback(options) {
       return next();
     }
 
-    rewriteTarget = options.index || '/index.html';
+    rewriteTarget = '/' + (options.index || 'index.html');
     logger('Rewriting', req.method, req.url, 'to', rewriteTarget);
     req.url = rewriteTarget;
     next();

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -217,7 +217,7 @@ tests['should support custom index file'] = function(test) {
 
   middleware(req, null, next);
 
-  test.equal(req.url, index);
+  test.equal(req.url, '/' + index);
   test.ok(next.called);
   test.done();
 };


### PR DESCRIPTION
I'm trying to set my index to something else in my webpack config.
according the README and the code here:

https://github.com/webpack/webpack-dev-middleware#index
https://github.com/webpack/webpack-dev-middleware/blob/master/lib/middleware.js#L81

I changed my config here.
```
// config.js
{ index: 'otherpage.html' }
// dev-server.js
webpackDevMiddleware({ index: config.index })
```
but it doesn't work as I expected. I found out `connect-history-api-fallback` will rewrite the url to 'index.html' from here:
https://github.com/bripkens/connect-history-api-fallback/blob/master/lib/index.js#L82

so I have to add  the following code to fix it:

```
history({
  index: config.index
});
```
but actually this is wrong, because I'm missing a '/' for it.

so I would expect the `index` always be the same meaning.