### PR TITLE
Fix issue with variable name

### DIFF
--- a/examples/static-files-and-index-rewrite/index.js
+++ b/examples/static-files-and-index-rewrite/index.js
@@ -18,5 +18,5 @@ app.get('/users/5.json', (req, res) => {
 
 const port = 5555;
 app.listen(port, () => {
-  console.log(`Example app listening on port ${5555}!`);
+  console.log(`Example app listening on port ${port}!`);
 });


### PR DESCRIPTION
```js
console.log(`Example app listening on port ${5555}!`);
```
should be
```js
console.log(`Example app listening on port ${port}!`);
```