### PR TITLE
Allow HEAD requests (Fixes #72)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,12 @@ exports = module.exports = function historyApiFallback(options) {
 
   return function(req, res, next) {
     var headers = req.headers;
-    if (req.method !== 'GET') {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
       logger(
         'Not rewriting',
         req.method,
         req.url,
-        'because the method is not GET.'
+        'because the method is not GET or HEAD.'
       );
       return next();
     } else if (!headers || typeof headers.accept !== 'string') {


### PR DESCRIPTION
This proposal handles `HEAD` requests similarly to `GET` requests, since they are essentially the same with the difference of `HEAD` response not containing a body.

If special handing for `HEAD` requests is needed, that can be set explicitly in `express` routing or otherwise.