### PR TITLE
feat: allow HEAD method for requests #72

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,12 @@ exports = module.exports = function historyApiFallback(options) {
 
   return function(req, res, next) {
     var headers = req.headers;
-    if (req.method !== 'GET') {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
       logger(
         'Not rewriting',
         req.method,
         req.url,
-        'because the method is not GET.'
+        'because the method is not GET or HEAD.'
       );
       return next();
     } else if (!headers || typeof headers.accept !== 'string') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,10 +24,9 @@ describe('connect-history-api-fallback', () => {
     next = sinon.stub();
   });
 
-  ['POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'].forEach(method => {
+  ['POST', 'PUT', 'DELETE', 'OPTIONS'].forEach(method => {
     it(`must ignore ${method} requests`, () => {
       req.method = method;
-
       middleware(req, null, next);
 
       expect(req.url).toEqual(requestedUrl);
@@ -35,209 +34,243 @@ describe('connect-history-api-fallback', () => {
     });
   });
 
-  it('should ignore requests that do not accept html', () => {
-    req.headers.accept = 'application/json';
+  ['GET', 'HEAD'].forEach(method => {
+    it(`[${method}] should ignore requests that do not accept html`, () => {
+      req.method = method;
+      req.headers.accept = 'application/json';
 
-    middleware(req, null, next);
+      middleware(req, null, next);
 
-    expect(req.url).toEqual(requestedUrl);
-    expect(next.called).toEqual(true);
-  });
-
-
-  it('should ignore file requests', () => {
-    var expected = req.url = 'js/app.js';
-
-    middleware(req, null, next);
-
-    expect(req.url).toEqual(expected);
-    expect(next.called).toEqual(true);
-  });
-
-
-  it('should rewrite requests with .', () => {
-    req.url = 'js/foo.bar/jkdsah321jkh';
-
-    middleware(req, null, next);
-
-    expect(req.url).toEqual('/index.html');
-    expect(next.called).toEqual(true);
-  });
-
-
-  it('should rewrite requests when the . rule is disabled', () => {
-    req.url = 'js/app.js';
-    middleware = historyApiFallback({
-      disableDotRule: true
-    });
-    middleware(req, null, next);
-
-    expect(req.url).toEqual('/index.html');
-    expect(next.called).toEqual(true);
-  });
-
-
-  it('should take JSON preference into account', () => {
-    req.headers.accept = 'application/json, text/plain, */*';
-
-    middleware(req, null, next);
-
-    expect(req.url).toEqual(requestedUrl);
-    expect(next.called).toEqual(true);
-  });
-
-
-  it('should rewrite valid requests', () => {
-    middleware(req, null, next);
-
-    expect(req.url).toEqual('/index.html');
-    expect(next.called).toEqual(true);
-  });
-
-  it('should not fail for missing HTTP accept header', () => {
-    delete req.headers.accept;
-
-    middleware(req, null, next);
-
-    expect(req.url).toEqual(requestedUrl);
-    expect(next.called).toEqual(true);
-  });
-
-  it('should not fail for missing headers object', () => {
-    delete req.headers;
-
-    middleware(req, null, next);
-
-    expect(req.url).toEqual(requestedUrl);
-    expect(next.called).toEqual(true);
-  });
-
-  it('should work in verbose mode', () => {
-    var expected = req.url = 'js/app.js';
-    middleware = historyApiFallback({
-      verbose: true
+      expect(req.url).toEqual(requestedUrl);
+      expect(next.called).toEqual(true);
     });
 
-    middleware(req, null, next);
 
-    expect(req.url).toEqual(expected);
-    expect(next.called).toEqual(true);
-  });
+    it(`[${method}] should ignore file requests`, () => {
+      req.method = method;
 
-  it('should work with a custom logger', () => {
-    var expected = req.url = 'js/app.js';
-    var logger = sinon.stub();
-    middleware = historyApiFallback({
-      logger: logger
+      var expected = req.url = 'js/app.js';
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual(expected);
+      expect(next.called).toEqual(true);
     });
 
-    middleware(req, null, next);
 
-    expect(req.url).toEqual(expected);
-    expect(next.called).toEqual(true);
-    expect(logger.calledOnce).toEqual(true);
-  });
+    it(`[${method}] should rewrite requests with .`, () => {
+      req.method = method;
+      req.url = 'js/foo.bar/jkdsah321jkh';
 
-  it('should rewrite requested path according to rules', () => {
-    req.url = '/soccer';
-    middleware = historyApiFallback({
-      rewrites: [
-        {from: /\/soccer/, to: '/soccer.html'}
-      ]
+      middleware(req, null, next);
+
+      expect(req.url).toEqual('/index.html');
+      expect(next.called).toEqual(true);
     });
 
-    middleware(req, null, next);
 
-    expect(req.url).toEqual('/soccer.html');
-    expect(next.called).toEqual(true);
-  });
+    it(`[${method}] should rewrite requests when the . rule is disabled`, () => {
+      req.method = method;
+      req.url = 'js/app.js';
 
-  it('should support functions as rewrite rule', () => {
-    middleware = historyApiFallback({
-      rewrites: [
-        {
-          from: /^\/libs\/(.*)$/,
-          to: function(context) {
-            return './bower_components' + context.parsedUrl.pathname;
-          }
-        }
-      ]
+      middleware = historyApiFallback({
+        disableDotRule: true
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual('/index.html');
+      expect(next.called).toEqual(true);
     });
 
-    req.url = '/libs/jquery/jquery.1.12.0.min.js';
-    middleware(req, null, next);
-    expect(req.url).toEqual('./bower_components/libs/jquery/jquery.1.12.0.min.js');
-    expect(next.called).toEqual(true);
 
-    next = sinon.stub();
-    var expected = req.url = '/js/main.js';
-    middleware(req, null, next);
-    expect(req.url).toEqual(expected);
-    expect(next.called).toEqual(true);
+    it(`[${method}] should take JSON preference into account`, () => {
+      req.method = method;
+      req.headers.accept = 'application/json, text/plain, */*';
 
-  });
+      middleware(req, null, next);
 
-  it('should test rewrite rules', () => {
-    req.url = '/socer';
-    middleware = historyApiFallback({
-      rewrites: [
-        {from: /\/soccer/, to: '/soccer.html'}
-      ]
+      expect(req.url).toEqual(requestedUrl);
+      expect(next.called).toEqual(true);
     });
 
-    middleware(req, null, next);
 
-    expect(req.url).toEqual('/index.html');
-    expect(next.called).toEqual(true);
-  });
+    it(`[${method}] should rewrite valid requests`, () => {
+      req.method = method;
 
-  it('should support custom index file', () => {
-    var index = 'default.html';
-    req.url = '/socer';
-    middleware = historyApiFallback({
-      index: index
+      middleware(req, null, next);
+
+      expect(req.url).toEqual('/index.html');
+      expect(next.called).toEqual(true);
     });
 
-    middleware(req, null, next);
+    it(`[${method}] should not fail for missing HTTP accept header`, () => {
+      req.method = method;
+      delete req.headers.accept;
 
-    expect(req.url).toEqual(index);
-    expect(next.called).toEqual(true);
-  });
+      middleware(req, null, next);
 
-  it('should accept html requests based on headers option', () => {
-    req.headers.accept = '*/*';
-    middleware = historyApiFallback({
-      htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+      expect(req.url).toEqual(requestedUrl);
+      expect(next.called).toEqual(true);
     });
 
-    middleware(req, null, next);
+    it(`[${method}] should not fail for missing headers object`, () => {
+      req.method = method;
+      delete req.headers;
 
-    expect(req.url).toEqual(requestedUrl);
-    expect(next.called).toEqual(true);
-  });
+      middleware(req, null, next);
 
-  it('should support custom rewrite rules', () => {
-    req.headers.accept = '*/*';
-    var url = '/app/login/app.js';
-    req.url = url;
-    middleware = historyApiFallback({
-      rewrites: [
-        {
-          from: /\/app\/login/,
-          to: function onMatch(ctx) {
-            if (ctx.parsedUrl.path.indexOf('.js')) {
-              return ctx.parsedUrl.href;
+      expect(req.url).toEqual(requestedUrl);
+      expect(next.called).toEqual(true);
+    });
+
+    it(`[${method}] should work in verbose mode`, () => {
+      req.method = method;
+
+      var expected = req.url = 'js/app.js';
+
+      middleware = historyApiFallback({
+        verbose: true
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual(expected);
+      expect(next.called).toEqual(true);
+    });
+
+    it(`[${method}] should work with a custom logger`, () => {
+      req.method = method;
+
+      var expected = req.url = 'js/app.js';
+      var logger = sinon.stub();
+
+      middleware = historyApiFallback({
+        logger: logger
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual(expected);
+      expect(next.called).toEqual(true);
+      expect(logger.calledOnce).toEqual(true);
+    });
+
+    it(`[${method}] should rewrite requested path according to rules`, () => {
+      req.method = method;
+      req.url = '/soccer';
+
+      middleware = historyApiFallback({
+        rewrites: [
+          {from: /\/soccer/, to: '/soccer.html'}
+        ]
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual('/soccer.html');
+      expect(next.called).toEqual(true);
+    });
+
+    it(`[${method}] should support functions as rewrite rule`, () => {
+      req.method = method;
+
+      middleware = historyApiFallback({
+        rewrites: [
+          {
+            from: /^\/libs\/(.*)$/,
+            to: function(context) {
+              return './bower_components' + context.parsedUrl.pathname;
             }
-            return '/app/login/index.html';
           }
-        }
-      ]
+        ]
+      });
+
+      req.url = '/libs/jquery/jquery.1.12.0.min.js';
+      middleware(req, null, next);
+      expect(req.url).toEqual('./bower_components/libs/jquery/jquery.1.12.0.min.js');
+      expect(next.called).toEqual(true);
+
+      next = sinon.stub();
+      var expected = req.url = '/js/main.js';
+      middleware(req, null, next);
+      expect(req.url).toEqual(expected);
+      expect(next.called).toEqual(true);
+
     });
 
-    middleware(req, null, next);
+    it(`[${method}] should test rewrite rules`, () => {
+      req.method = method;
+      req.url = '/socer';
 
-    expect(req.url).toEqual(url);
-    expect(next.called).toEqual(true);
+      middleware = historyApiFallback({
+        rewrites: [
+          {from: /\/soccer/, to: '/soccer.html'}
+        ]
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual('/index.html');
+      expect(next.called).toEqual(true);
+    });
+
+    it(`[${method}] should support custom index file`, () => {
+      req.method = method;
+      req.url = '/socer';
+
+      var index = 'default.html';
+
+      middleware = historyApiFallback({
+        index: index
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual(index);
+      expect(next.called).toEqual(true);
+    });
+
+    it(`[${method}] should accept html requests based on headers option`, () => {
+      req.method = method;
+      req.headers.accept = '*/*';
+
+      middleware = historyApiFallback({
+        htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual(requestedUrl);
+      expect(next.called).toEqual(true);
+    });
+
+    it(`[${method}] should support custom rewrite rules`, () => {
+      req.method = method;
+      req.headers.accept = '*/*';
+
+      var url = '/app/login/app.js';
+      req.url = url;
+
+      middleware = historyApiFallback({
+        rewrites: [
+          {
+            from: /\/app\/login/,
+            to: function onMatch(ctx) {
+              if (ctx.parsedUrl.path.indexOf('.js')) {
+                return ctx.parsedUrl.href;
+              }
+              return '/app/login/index.html';
+            }
+          }
+        ]
+      });
+
+      middleware(req, null, next);
+
+      expect(req.url).toEqual(url);
+      expect(next.called).toEqual(true);
+    });
   });
 
 });


### PR DESCRIPTION
I decided to fix this problem: https://github.com/bripkens/connect-history-api-fallback/issues/72

In my case, this fix was needed because I had a similar problem as described in issue.

We have a `Kubernetes` system that periodically polls the project build so that it completes and the `webpack-dev-server` is ready to accept requests.

Instead of making GET requests, Kubernetis sends HEAD requests and this behavior cannot be changed in any way =(

_In addition, it would be nice to bring requests to the HTTP standard. Yet GET and HEAD should work in the same way._